### PR TITLE
remove the x.x.x.x from the blank IP in switcher

### DIFF
--- a/ServiceVault/wtv-tricks/switcher.js
+++ b/ServiceVault/wtv-tricks/switcher.js
@@ -87,7 +87,7 @@ hspace="0" vspace="0" fontsize="large" noscroll>
 		srv = document.connect.preset[document.connect.preset.selectedIndex].value;
 		switch (srv) {
 				case "noneofem":
-					document.connect.machine.value="x.x.x.x"
+					document.connect.machine.value=""
                     document.connect.port.value="1615"
 					document.message.msg.value="Choose a WebTV server to connect to."
 					break;


### PR DESCRIPTION
(makes it easier to type in a custom IP, since you don't have to cmd+delete or anything like that beforehand)