### PR TITLE
fix email tutorial page

### DIFF
--- a/ServiceVault/wtv-mail/DiplomaMail.js
+++ b/ServiceVault/wtv-mail/DiplomaMail.js
@@ -57,9 +57,7 @@ In Mail, you can exchange typed messages&#151;called
     wtvrsvc_config.config.service_name
 }. This is your e-mail address:
 <blockquote>
-<b>${session_data.getSessionData("subscriber_username")}@${
-    wtvrsvc_config.config.service_name
-}</b>
+<b>${session_data.getSessionData("subscriber_username")}@webtv.zone</b>
 </blockquote>
 Choose <b>Begin</b> to start using Mail. <!-- Or to learn more,
 choose this link:


### PR DESCRIPTION
makes it actually display webtv.zone instead of WebTV on wtv-mail:/DiplomaMail (the page that gets shown when you first open mail)

it's hardcoded now rather than using the service name, however that should be easy to reimplement as another config option or something if the need arises